### PR TITLE
Fix achievement fetch failing if earned_time for goldberg is a string

### DIFF
--- a/source/Clients/SteamAchievements.cs
+++ b/source/Clients/SteamAchievements.cs
@@ -144,7 +144,7 @@ namespace SuccessStory.Clients
             {               
                 if (IsManual)
                 {                   
-                    appId = SteamApi.GetAppId(game.Name);
+                    appId = SteamApi.GetAppId(game);
                     gameAchievements = GetManual(appId, game);
                 }
 
@@ -272,7 +272,7 @@ namespace SuccessStory.Clients
 
             if (appId == 0)
             {
-                appId = SteamApi.GetAppId(game.Name);
+                appId = SteamApi.GetAppId(game);
             }
             ObservableCollection<GameAchievement> steamAchievements = SteamApi.GetAchievements(appId.ToString(), null);
 

--- a/source/Clients/SteamEmulators.cs
+++ b/source/Clients/SteamEmulators.cs
@@ -134,7 +134,7 @@ namespace SuccessStory.Clients
             }
             else
             {
-                this.AppId = AppId != 0 ? AppId : steamApi.GetAppId(game.Name);
+                this.AppId = AppId != 0 ? AppId : steamApi.GetAppId(game);
             }
 
             SteamEmulatorData data = Get(game, this.AppId, apiKey, IsManual);
@@ -784,11 +784,16 @@ namespace SuccessStory.Clients
 
 
                                     dynamic elements = achievement.First;
-                                    dynamic unlockedTimeToken = elements.SelectToken("earned_time");
+                                    dynamic unlockedTimeToken = elements.SelectToken("earned_time").Value;
 
-                                    if (unlockedTimeToken.Value > 0)
+                                    if (unlockedTimeToken is string)
                                     {
-                                        DateUnlocked = new DateTime(1970, 1, 1).AddSeconds(unlockedTimeToken.Value);
+                                        unlockedTimeToken = UInt64.Parse(unlockedTimeToken);
+                                    }
+
+                                    if (unlockedTimeToken > 0)
+                                    {
+                                        DateUnlocked = new DateTime(1970, 1, 1).AddSeconds(unlockedTimeToken);
                                     }
 
                                     if (Name != string.Empty && DateUnlocked != null)


### PR DESCRIPTION
Also changed this in playnite-plugincommon\CommonPluginsStores\Steam\SteamApi L698, it will try to get app id from metadata links which works better than just checking the game's name (if using something like IGDB to fill metadata).

```
public uint GetAppId(Game game)
{
    var appIdFromLinks = GetAppIdFromLinks(game);
    if (appIdFromLinks != 0) return appIdFromLinks;

    if (SteamApps == null)
    {
        Logger.Warn("SteamApps is empty");
        return 0;
    }

    SteamApps.Sort((x, y) => x.AppId.CompareTo(y.AppId));
    List<uint> found = SteamApps.FindAll(x => x.Name.IsEqual(game.Name, true)).Select(x => x.AppId).Distinct().ToList();

    if (found != null && found.Count > 0)
    {
        if (found.Count > 1)
        {
            Logger.Warn($"Found {found.Count} SteamAppId data for {game.Name}: " + string.Join(", ", found));
            return 0;
        }

        Common.LogDebug(true, $"Found SteamAppId data for {game.Name} - {Serialization.ToJson(found)}");
        return found.First();
    }

    return 0;
}

private uint GetAppIdFromLinks(Game game)
{
    var steamLink = game.Links?.FirstOrDefault(link => link.Name.ToLower() == "steam");
    if (steamLink == null) return 0;

    var linkSplit = steamLink.Url.Split(new[] { "/app/" }, StringSplitOptions.None);
    var steamIdString = linkSplit?.ElementAtOrDefault(1)?.Split('/').FirstOrDefault();
    if (steamIdString == null) return 0;

    var success = UInt32.TryParse(steamIdString, out var steamId);
    if (!success) return 0;

    return steamId;
}
```